### PR TITLE
Tweets werden nicht automatisch erzeugt

### DIFF
--- a/inc/model/articles/article.php
+++ b/inc/model/articles/article.php
@@ -786,11 +786,12 @@
         
         /**
          * Erzeugt einen Tweet bei Twitter, wenn Verbindung aktiv und Events ausgewählt
+         * @param bool $force
          * @return boolean
          */
-        public function createTweet() {
+        public function createTweet($force = false) {
 
-            if (!\fpcm\classes\baseconfig::canConnect() || (!$this->config->twitter_events['create'] && !$this->config->twitter_events['update'])) {
+            if (!\fpcm\classes\baseconfig::canConnect() || (!$this->config->twitter_events['create'] && !$this->config->twitter_events['update'] && !$force)) {
                 return false;
             }
 

--- a/inc/model/crons/postponedArticles.php
+++ b/inc/model/crons/postponedArticles.php
@@ -27,9 +27,34 @@
             if (!count($articleIds)) {
                 return true;
             }
-            
-            $articlesList->publishPostponedArticles($articleIds);
-            
+
+            if (!$articlesList->publishPostponedArticles($articleIds)) {
+                return false;
+            }
+
+            $params = array('ids' => $articleIds);
+            $articles = $articlesList->getArticlesByCondition($params, false);
+
+            $failed = array();
+            foreach ($articles as $article) {
+
+                /**
+                 * @var \fpcm\model\articles\article $article
+                 */
+                if ($article->createTweet(true)) {
+                    continue;
+                }
+
+                $failed[] = $article->getId();
+                sleep(1);
+
+            }
+
+            if (!count($failed)) {
+                return true;
+            }
+
+            trigger_error('Failed to create tweets for postponed articles. Affected article ids: '.PHP_EOL. implode(', ', $failed));
             return true;            
         }
         


### PR DESCRIPTION
Tweets werden nicht erzeugt, wenn Artikel automatisch freigeschlaten werden